### PR TITLE
fixed case mistake in require('isstream')

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var Readable = require('stream').Readable;
 
-var isStream = require('isStream');
+var isStream = require('isstream');
 var base64 = require('base64-stream');
 
 module.exports = function (filePathOrStream, callback) {


### PR DESCRIPTION
this is probably only a problem on case sensitive file systems.

if you're working on OSX consider making a 'case sensitive, journaled' disk image for node development